### PR TITLE
task-WDP180901-16

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -540,7 +540,7 @@
     <div class="footer-menu">
       <div class="container">
         <div class="row">
-          <div class="col">
+          <div class="col col-6 col-sm-6 col-md-3">
             <div class="menu-wrapper">
               <h6>Information</h6>
               <ul>
@@ -551,7 +551,7 @@
               </ul>
             </div>
           </div>
-          <div class="col">
+          <div class="col col-6 col-sm-6 col-md-3">
             <div class="menu-wrapper">
               <h6>My account</h6>
               <ul>
@@ -562,7 +562,7 @@
               </ul>
             </div>
           </div>
-          <div class="col">
+          <div class="col col-6 col-sm-6 col-md-3">
             <div class="menu-wrapper">
               <h6>Information</h6>
               <ul>
@@ -573,7 +573,7 @@
               </ul>
             </div>
           </div>
-          <div class="col">
+          <div class="col col-6 col-sm-6 col-md-3">
             <div class="menu-wrapper">
               <h6>Orders</h6>
               <ul>
@@ -591,11 +591,11 @@
     <div class="bottom-bar">
       <div class="container">
         <div class="row align-items-center">
-          <div class="col"></div>
-          <div class="col copyright text-center">
+          <div class="col col-12 col-md-12 col-lg-4"></div>
+          <div class="col col-12 col-sm-6 col-md-6 col-lg-4 copyright text-center">
             <p>©Copyright 2016 Bazar | All Rights Reserved</p>
           </div>
-          <div class="col socialmedia text-right">
+          <div class="col col-12 col-sm-6 col-md-6 col-lg-4 socialmedia text-md-right text-center">
             <ul>
               <li><a href="#"><i class="fab fa-twitter"></i></a></li>
               <li><a href="#"><i class="fab fa-facebook-f"></i></a></li>

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -28,6 +28,11 @@ footer {
       }
     }
 
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
     .payment-methods {
       margin: 0;
       padding: 0;
@@ -37,21 +42,32 @@ footer {
         display: inline-block;
       }
     }
+
+    @media (max-width: 320px) {
+      .container>.row>.col {
+        max-width: 100%;
+        flex: 0 0 100%;
+      }
+    }
   }
 
   .bottom-bar {
     background-color: $footer-claim-bg;
 
-    .container > .row {
+    .container>.row {
       height: 95px;
     }
 
     .copyright {
       p {
         margin: 0;
-        color: rgb(169,169,169);
+        color: rgb(169, 169, 169);
         font-size: 14px;
         line-height: 26px;
+      }
+
+      @media (max-width: 991.98px) {
+        order: 2;
       }
     }
 
@@ -74,6 +90,10 @@ footer {
             }
           }
         }
+      }
+
+      @media (max-width: 991.98px) {
+        order: 3;
       }
     }
   }

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -17,8 +17,11 @@ footer {
         li {
           a {
             font-size: 14px;
-            line-height: 30px;
+            line-height: normal;
             color: rgb(169,169,169);
+            display: block;
+            margin-bottom: 7px;
+            margin-top: 7px;
 
             &:hover {
               color: #ffffff;


### PR DESCRIPTION
Brakuje RWD footera.
Górna partia stopki na mniejszych ekranach ma mieć dwie sekcje na szerokość, a jak w najmniejszych rozdzielczościach nie będą się mieścić, to nawet 1 na szerokość. W dolnym pasku na tablecie copyright ma być do lewej, a socjalki do prawej. Tam jest obecnie specjalnie zostawione miejsce po lewej, w którym na razie niczego nie ma, to coś ma być wyśrodkowane i na całą szerokość (nad copyright i socjalkami). 
Wykonałam + dodałam RWD dla grafiki z kartami płatniczymi. 