### PR TITLE
bug-WDP180901-9

### DIFF
--- a/src/sass/_page-styles.scss
+++ b/src/sass/_page-styles.scss
@@ -1,9 +1,13 @@
-.hover-color-animation {
+%hover-color-animation {
   transition-property: color, background-color, border-color;
   transition-duration: .25s, .25s, .25s;
   transition-timing-function: linear;
 }
 
-.hover-opacity-animation {
+%hover-opacity-animation {
   transition: opacity .25s linear;
+}
+
+%hover-transform-animation {
+  transition: transform .25s linear;
 }

--- a/src/sass/_page-styles.scss
+++ b/src/sass/_page-styles.scss
@@ -1,0 +1,9 @@
+.hover-color-animation {
+  transition-property: color, background-color, border-color;
+  transition-duration: .25s, .25s, .25s;
+  transition-timing-function: linear;
+}
+
+.hover-opacity-animation {
+  transition: opacity .25s linear;
+}

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -1,4 +1,5 @@
 .btn-main {
+  @extend .hover-color-animation;
   background-color: #2a2a2a;
   color: #ffffff;
   font-size: 16px;
@@ -22,6 +23,7 @@
 }
 
 .btn-outline {
+  @extend .hover-color-animation;
   display: inline-block;
   padding: 5px 10px;
   border: 1px solid #2a2a2a;

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -1,5 +1,5 @@
 .btn-main {
-  @extend .hover-color-animation;
+  @extend %hover-color-animation;
   background-color: #2a2a2a;
   color: #ffffff;
   font-size: 16px;
@@ -23,7 +23,7 @@
 }
 
 .btn-outline {
-  @extend .hover-color-animation;
+  @extend %hover-color-animation;
   display: inline-block;
   padding: 5px 10px;
   border: 1px solid #2a2a2a;

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -9,7 +9,7 @@
     transform: translateY(-50%);
 
     i {
-      @extend .hover-color-animation;
+      @extend %hover-color-animation;
       width: 60px;
       height: 60px;
       border-radius: 100%;
@@ -37,7 +37,7 @@
   }
 
   .content {
-    @extend .hover-color-animation;
+    @extend %hover-color-animation;
     text-transform: uppercase;
     color: rgb(42,42,42);
     margin-top: -0.5rem;

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -9,6 +9,7 @@
     transform: translateY(-50%);
 
     i {
+      @extend .hover-color-animation;
       width: 60px;
       height: 60px;
       border-radius: 100%;
@@ -36,6 +37,7 @@
   }
 
   .content {
+    @extend .hover-color-animation;
     text-transform: uppercase;
     color: rgb(42,42,42);
     margin-top: -0.5rem;

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -16,7 +16,7 @@ footer {
         list-style: none;
         li {
           a {
-            @extend .hover-color-animation;
+            @extend %hover-color-animation;
             font-size: 14px;
             line-height: 30px;
             color: rgb(169,169,169);
@@ -67,7 +67,7 @@ footer {
           margin-left: 1rem;
 
           a {
-            @extend .hover-color-animation;
+            @extend %hover-color-animation;
             color: rgb(169,169,169);
             text-decoration: none;
 

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -16,6 +16,7 @@ footer {
         list-style: none;
         li {
           a {
+            @extend .hover-color-animation;
             font-size: 14px;
             line-height: 30px;
             color: rgb(169,169,169);
@@ -66,6 +67,7 @@ footer {
           margin-left: 1rem;
 
           a {
+            @extend .hover-color-animation;
             color: rgb(169,169,169);
             text-decoration: none;
 

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -12,6 +12,7 @@ header {
         line-height: 55px;
 
         a {
+          @extend .hover-color-animation;
           color: #ffffff;
           font-size: 13px;
 
@@ -72,6 +73,7 @@ header {
         color: #ffffff;
 
         .cart-icon {
+          @extend .hover-color-animation;
           background-color: $primary;
           width: 55px;
           height: 50px;
@@ -131,6 +133,7 @@ header {
           align-items: stretch;
 
           a {
+            @extend .hover-color-animation;
             color: $text-color;
             text-transform: uppercase;
             font-size: 12px;
@@ -225,6 +228,7 @@ header {
           transition: transform .25s;
 
           li {
+            @extend .hover-color-animation;
             border: 1px solid $form-border-color;
             margin-top: -1px;
             height: 45px;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -12,7 +12,7 @@ header {
         line-height: 55px;
 
         a {
-          @extend .hover-color-animation;
+          @extend %hover-color-animation;
           color: #ffffff;
           font-size: 13px;
 
@@ -73,7 +73,7 @@ header {
         color: #ffffff;
 
         .cart-icon {
-          @extend .hover-color-animation;
+          @extend %hover-color-animation;
           background-color: $primary;
           width: 55px;
           height: 50px;
@@ -127,13 +127,17 @@ header {
         padding: 0;
         display: flex;
 
+        &.transition {
+          @extend %hover-transform-animation;
+        }
+
         li {
           list-style: none;
           display: flex;
           align-items: stretch;
 
           a {
-            @extend .hover-color-animation;
+            @extend %hover-color-animation;
             color: $text-color;
             text-transform: uppercase;
             font-size: 12px;
@@ -221,14 +225,14 @@ header {
 
         .first-level {
           @extend .dropdown-list;
+          @extend %hover-transform-animation;
           width: calc(100% + 2px);
           left: -1px;
           transform: scaleY(0);
           transform-origin: top;
-          transition: transform .25s;
 
           li {
-            @extend .hover-color-animation;
+            @extend %hover-color-animation;
             border: 1px solid $form-border-color;
             margin-top: -1px;
             height: 45px;
@@ -257,12 +261,12 @@ header {
 
         .second-level {
           @extend .dropdown-list;
+          @extend %hover-transform-animation;
           width: 100%;
           left: calc(100% - 1px);
           margin-top: -45px;
           transform: scaleX(0);
           transform-origin: left;
-          transition: transform .25s;
         }
       }
 
@@ -329,10 +333,6 @@ header {
           left: 0;
           z-index: 500;
           box-shadow: 0 3.464px 6px rgba(1,2,2,0.2);
-
-          &.transition {
-            transition: transform .25s ease-in-out;
-          }
 
           &.show {
             transform: scaleY(1);

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -1,6 +1,6 @@
 .panel-bar {
   margin-bottom: 30px;
-  
+
   .row > * {
     border-bottom: 4px solid #e2e2e2;
   }
@@ -45,15 +45,20 @@
           font-size: 18px;
           display: block;
 
+          &::before {
+            @extend .hover-color-animation;
+            content: '';
+            position: absolute;
+            bottom: -4px;
+            left: 0;
+            width: 100%;
+            border-bottom: 4px solid rgba(0,0,0,0);
+          }
+
           &.active,
           &:hover {
             &::before {
-              content: '';
-              position: absolute;
-              bottom: -4px;
-              left: 0;
-              width: 100%;
-              border-bottom: 4px solid $primary;
+              border-color: $primary;
             }
           }
         }
@@ -74,6 +79,7 @@
         margin-left: 0.5rem;
 
         a {
+          @extend .hover-color-animation;
           display: block;
           width: 13px;
           height: 13px;

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -46,7 +46,7 @@
           display: block;
 
           &::before {
-            @extend .hover-color-animation;
+            @extend %hover-color-animation;
             content: '';
             position: absolute;
             bottom: -4px;
@@ -79,7 +79,7 @@
         margin-left: 0.5rem;
 
         a {
-          @extend .hover-color-animation;
+          @extend %hover-color-animation;
           display: block;
           width: 13px;
           height: 13px;

--- a/src/sass/components/_post-box.scss
+++ b/src/sass/components/_post-box.scss
@@ -4,6 +4,10 @@
   .cover-link {
     text-decoration: none;
 
+    .post-info h5 {
+      @extend .hover-color-animation;
+    }
+
     &:hover .post-info h5 {
       color: $primary;
     }

--- a/src/sass/components/_post-box.scss
+++ b/src/sass/components/_post-box.scss
@@ -5,7 +5,7 @@
     text-decoration: none;
 
     .post-info h5 {
-      @extend .hover-color-animation;
+      @extend %hover-color-animation;
     }
 
     &:hover .post-info h5 {

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -29,10 +29,10 @@
     }
 
     .buttons {
+      @extend .hover-opacity-animation;
       display: flex;
       justify-content: space-between;
       opacity: 0;
-      transition: opacity .3s;
     }
   }
 

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -29,7 +29,7 @@
     }
 
     .buttons {
-      @extend .hover-opacity-animation;
+      @extend %hover-opacity-animation;
       display: flex;
       justify-content: space-between;
       opacity: 0;

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -8,6 +8,8 @@
 @import "fontawesome/brands";
 @import "fontawesome/regular";
 
+@import "page-styles";
+
 @import "components/header";
 @import "components/footer";
 


### PR DESCRIPTION
Według wytycznych należało nadać jednakowy efekt animacji koloru tła / tekstu dla wszystkich elementów z pseudo klasą :hover. Klient miał mieć możliwość łatwej zmiany czasów tych animacji (globalnie dla wszystkich elementów) oraz możliwość ustawienia różnych czasów animacji dla tekstu / koloru tła. Według wytycznych należało wykonać zadanie stosując extendowanie placeholdera oraz dodać style do każdego z hoverowanych elementów (ale tylko do nich).

Dodano plik src/sass/_page-styles.scss zawierający "ciche klasy" ze stylami na animacje kolorów tła/tekstu. Dodano "dziedziczenie" tych styli ( za pom. @extend) do każdej klasy ze zmianą kolorów tła/tekstu na hover. 