### PR TITLE
task-WDP180901-23

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -107,6 +107,76 @@
       </div>
     </div>
   </header>
+  <div class="section--promoted">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-4">
+          <div class="hot-deals">
+            <div class="photo">
+              <div class="row no-gutters align-items-end header">
+                <div class="col-6 heading">
+                  <h3>Hot deals</h3>
+                </div>
+                <div class="col-6 dots">
+                  <ul class="align-items-end">
+                    <li><a href="#" active></a></li>
+                    <li><a href="#"></a></li>
+                    <li><a href="#"></a></li>
+                  </ul>
+                </div>
+              </div>
+              <div class="buttons">
+                <a href="#" class="btn-main-small"><i class="fa fa-shopping-basket"></i> ADD TO CART</a>
+              </div>
+              <div class="counter">
+                <div class="round-box"><h4>25</h4><h6>days</h6></div>
+                <div class="round-box"><h4>10</h4><h6>hrs</h6></div>
+                <div class="round-box"><h4>45</h4><h6>mins</h6></div>
+                <div class="round-box"><h4>30</h4><h6>secs</h6></div>
+              </div>
+            </div>
+            <div class="content">
+              <h5>Aenean Ru Bristique</h5>
+              <div class="stars">
+                <a href="#" class="full"></a>
+                <a href="#" class="full"></a>
+                <a href="#"></a>
+                <a href="#"></a>
+                <a href="#"></a>
+              </div>
+            </div>
+            <div class="line"></div>
+            <div class="actions">
+              <div class="outlines">
+                <a href="#" class="btn-outline"><i class="far fa-eye"></i></a>
+                <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
+                <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
+              </div>
+              <div class="price">
+                <div class="old-price">$350.00</div>
+                <div class="btn-main-small no-hover">$ 300.00</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-8">
+          <div class="highlight-products">
+            <div class="text">
+              <h1>Indoor <span class="black">Furniture</span></h1>
+              <h4>Save up to 50% of all furniture</h4>
+              <div class="action-btn">
+                <a href="#" class="btn-main">shop now</a>
+              </div>
+            </div>
+            <div class="control-buttons">
+              <a href="#" class="btn-main"><i class="fas fa-angle-left"></i></a>
+              <a href="#" class="btn-main"><i class="fas fa-angle-right"></i></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="section--features">
     <div class="container">
       <div class="row">
@@ -175,7 +245,7 @@
           </div>
           <div class="col-auto dots">
             <ul>
-              <li><a href="#" class="active"></a></li>
+              <li><a href="#" active></a></li>
               <li><a href="#"></a></li>
               <li><a href="#"></a></li>
             </ul>

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -1,4 +1,6 @@
 header {
+  position: relative;
+  z-index: 1;
   .top-bar {
     background-color: $header-topbar-bg;
 

--- a/src/sass/components/_highlight-products.scss
+++ b/src/sass/components/_highlight-products.scss
@@ -1,0 +1,72 @@
+.highlight-products {
+  position: relative;
+  padding-top:136px;
+  width: 100%;
+  height: 485px;
+  background: {
+    color: #cccccc;
+    size: cover;
+    position: center;
+    repeat: no-repeat;
+  }
+
+  .text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 210px;
+    background-color: rgba(0,0,0,.5);
+    color: white;
+    text-align: center;
+    text-transform: uppercase;
+
+    h1 {
+      margin-bottom: 0;
+      font-size: 3.2rem;
+      font-weight: 300;
+
+      .black {
+        font-weight: 700;
+        letter-spacing: 2px;
+      }
+    }
+
+    h4 {
+      font-weight: 300;
+    }
+
+    .action-btn {
+      position: absolute;
+      text-align: center;
+      text-transform: uppercase;
+      transform: translateY(105px);
+
+      .btn-main {
+        color: $text-color;
+        background-color: #ffffff;
+        margin-top: -20px;
+        border-radius: 3px;
+        padding: 16px 30px;
+
+        &:hover {
+          color: #ffffff;
+          background-color: $text-color;
+        }
+      }
+    }
+  }
+
+  .control-buttons {
+    position: absolute;
+    width: 100%;
+    bottom: 0;
+    left: 0;
+
+    .btn-main {
+      float: left;
+      width: 50%;
+      text-align: center;
+    }
+  }
+}

--- a/src/sass/components/_hot-deals.scss
+++ b/src/sass/components/_hot-deals.scss
@@ -3,14 +3,18 @@
   position: relative;
 
   .photo {
-    padding: 42% 10px 0 10px;
+    padding: 40% 10px 0 10px;
 
     .buttons {
       justify-content: center;
     }
 
     .counter {
-      margin-top: 75px;
+      /*Kiedy branch bug-WDP180901-9 zostanie zmergowany do mastera, należy odkomentoać poniższą linię kodu w celu dodania animacji przezroczystości tego elementu jedolitej pozostałą treścią strony
+      extend %hover-opacity-animation;
+      */
+      margin-top: 77px;
+      margin-bottom: 10px;
       color: #fff;
       text-align: center;
       opacity: 0;

--- a/src/sass/components/_hot-deals.scss
+++ b/src/sass/components/_hot-deals.scss
@@ -1,0 +1,84 @@
+.hot-deals {
+  @extend .product-box;
+  position: relative;
+
+  .photo {
+    padding: 42% 10px 0 10px;
+
+    .buttons {
+      justify-content: center;
+    }
+
+    .counter {
+      margin-top: 75px;
+      color: #fff;
+      text-align: center;
+      opacity: 0;
+
+      .round-box {
+        margin: 0 .05rem;
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        width: 4.4rem;
+        height: 4.4rem;
+        background-color: $header-bg;
+        border-radius: 50%;
+
+        h4 {
+          margin-bottom: .1rem;
+        }
+
+        h6 {
+          margin: 0;
+          text-transform: uppercase;
+          font-size: .85rem;
+        }
+      }
+    }
+
+    &:hover .counter {
+      opacity: 1;
+    }
+
+    &:hover .buttons {
+      opacity: 1;
+    }
+  }
+
+  .header {
+    @extend .panel-bar;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    background-color: #2a2a2a;
+    padding: 5px 20px;
+
+    .heading {
+      &::before {
+        display: none;
+      }
+
+      h3 {
+        color: #fff;
+      }
+    }
+
+    .dots ul {
+      background-color: rgba(0,0,0,0);
+      text-align: right;
+      transform: translateY(-5px);
+
+      li {
+        margin-left: 0.3rem;
+      }
+    }
+
+  }
+
+  &:hover .buttons{
+    opacity: 0;
+  }
+}

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -1,6 +1,6 @@
 .panel-bar {
   margin-bottom: 30px;
-  
+
   .row > * {
     border-bottom: 4px solid #e2e2e2;
   }
@@ -82,6 +82,10 @@
 
           &.active,
           &:hover {
+            background-color: $primary;
+          }
+
+          &[active] {
             background-color: $primary;
           }
         }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -45,7 +45,6 @@
     padding: 20px;
 
     h5 {
-      color: $primary;
       font-size: 16px;
       line-height: 24px;
       letter-spacing: 1px;
@@ -135,5 +134,9 @@
   &:hover .price .btn-main-small {
     color: #ffffff;
     background-color: $primary;
+  }
+
+  &:hover .content h5 {
+    color: $primary;
   }
 }

--- a/src/sass/components/_section--features.scss
+++ b/src/sass/components/_section--features.scss
@@ -1,3 +1,3 @@
 .section--features {
-  padding: 5rem 0;
+  padding-bottom: 5rem;
 }

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -16,6 +16,8 @@
 @import "components/panel-bar";
 @import "components/post-box";
 @import "components/product-box";
+@import "components/hot-deals";
+@import "components/highlight-products";
 
 @import "components/section--features";
 


### PR DESCRIPTION
Według wytycznych należało dodać **sekcję "promowane"** (tylko HTML + CSS, implementacja RWD do tej sekcji jest częścią innego taska).

**1. Karta produktu po lewej:**
- Kropki obok nagłówka "Hot deals" mają być pomarańczowe na hover oraz gdy dany slajd jest aktywny (oskryptowanie slidera będzie częścią innego taska, tutaj należy tylko przewidzieć w CSS aktywny stan dla danej kropki).
- Button "Add to cart" oraz licznik (statyczny, animację klient stworzy we własnym zakresie) mają pojawiać się na hover zdjęcia produktu.
- Trzy przyciski po lewej stronie od ceny mają mieć taki sam efekt hover, jak inne elementy tego typu na stronie.

**2. Wyróżniony produkt po prawej:**
- Półprzezroczysty pasek z tytułem i button "Shop now" mają być zawsze widoczne.
- Buttony ze strzałkami w prawo i w lewo pod zdjęciem mają stawać się pomarańczowe na hover.

Stworzono sekcję wg wytycznych.